### PR TITLE
Add for_each, fold, and rfold

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1132,6 +1132,15 @@ where
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
     }
+
+    #[inline]
+    fn fold<Acc, Fold>(self, init: Acc, f: Fold) -> Acc
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, &Self::Item) -> Acc,
+    {
+        self.0.rfold(init, f)
+    }
 }
 
 impl<I> DoubleEndedStreamingIterator for Rev<I>
@@ -1146,6 +1155,15 @@ where
     #[inline]
     fn next_back(&mut self) -> Option<&I::Item> {
         self.0.next()
+    }
+
+    #[inline]
+    fn rfold<Acc, Fold>(self, init: Acc, f: Fold) -> Acc
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, &Self::Item) -> Acc,
+    {
+        self.0.fold(init, f)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,6 +416,20 @@ pub trait DoubleEndedStreamingIterator: StreamingIterator {
         self.advance_back();
         (*self).get()
     }
+
+    /// Reduces the iterator's elements to a single, final value, starting from the back.
+    #[inline]
+    fn rfold<B, F>(mut self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, &Self::Item) -> B,
+    {
+        let mut acc = init;
+        while let Some(item) = self.next_back() {
+            acc = f(acc, item);
+        }
+        acc
+    }
 }
 
 /// Turns a normal, non-streaming iterator into a streaming iterator.
@@ -1368,5 +1382,21 @@ mod test {
         let mut acc = 0;
         it.for_each(|i| acc = acc * 10 + i);
         assert_eq!(acc, 123);
+    }
+
+    #[test]
+    fn rfold() {
+        let items = [0, 1, 2, 3];
+        let it = convert(items.iter().cloned());
+        assert_eq!(it.rfold(0, |acc, i| acc * 10 + i), 3210);
+    }
+
+    #[test]
+    fn for_each_rev() {
+        let items = [0, 1, 2, 3];
+        let it = convert(items.iter().cloned());
+        let mut acc = 0;
+        it.rev().for_each(|i| acc = acc * 10 + i);
+        assert_eq!(acc, 3210);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,8 @@
 #[cfg(feature = "std")]
 extern crate core;
 
-use core::marker::PhantomData;
 use core::cmp;
+use core::marker::PhantomData;
 
 /// An interface for dealing with streaming iterators.
 pub trait StreamingIterator {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -690,6 +690,25 @@ where
     fn size_hint(&self) -> (usize, Option<usize>) {
         (0, self.it.size_hint().1)
     }
+
+    #[inline]
+    fn fold<Acc, Fold>(self, init: Acc, mut fold: Fold) -> Acc
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, &Self::Item) -> Acc,
+    {
+        let mut f = self.f;
+        self.it.fold(
+            init,
+            move |acc, item| {
+                if f(item) {
+                    fold(acc, item)
+                } else {
+                    acc
+                }
+            },
+        )
+    }
 }
 
 impl<I, F> DoubleEndedStreamingIterator for Filter<I, F>
@@ -704,6 +723,25 @@ where
                 break;
             }
         }
+    }
+
+    #[inline]
+    fn rfold<Acc, Fold>(self, init: Acc, mut fold: Fold) -> Acc
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, &Self::Item) -> Acc,
+    {
+        let mut f = self.f;
+        self.it.rfold(
+            init,
+            move |acc, item| {
+                if f(item) {
+                    fold(acc, item)
+                } else {
+                    acc
+                }
+            },
+        )
     }
 }
 
@@ -747,6 +785,19 @@ where
     fn size_hint(&self) -> (usize, Option<usize>) {
         (0, self.it.size_hint().1)
     }
+
+    #[inline]
+    fn fold<Acc, Fold>(self, init: Acc, mut fold: Fold) -> Acc
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, &Self::Item) -> Acc,
+    {
+        let mut f = self.f;
+        self.it.fold(init, move |acc, item| match f(item) {
+            Some(item) => fold(acc, &item),
+            None => acc,
+        })
+    }
 }
 
 impl<I, B, F> DoubleEndedStreamingIterator for FilterMap<I, B, F>
@@ -768,6 +819,19 @@ where
                 }
             }
         }
+    }
+
+    #[inline]
+    fn rfold<Acc, Fold>(self, init: Acc, mut fold: Fold) -> Acc
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, &Self::Item) -> Acc,
+    {
+        let mut f = self.f;
+        self.it.rfold(init, move |acc, item| match f(item) {
+            Some(item) => fold(acc, &item),
+            None => acc,
+        })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -962,6 +962,16 @@ where
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.it.size_hint()
     }
+
+    #[inline]
+    fn fold<Acc, Fold>(self, init: Acc, mut fold: Fold) -> Acc
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, &Self::Item) -> Acc,
+    {
+        let mut f = self.f;
+        self.it.fold(init, move |acc, item| fold(acc, &f(item)))
+    }
 }
 
 impl<I, B, F> DoubleEndedStreamingIterator for Map<I, B, F>
@@ -972,6 +982,16 @@ where
     #[inline]
     fn advance_back(&mut self) {
         self.item = self.it.next_back().map(&mut self.f);
+    }
+
+    #[inline]
+    fn rfold<Acc, Fold>(self, init: Acc, mut fold: Fold) -> Acc
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, &Self::Item) -> Acc,
+    {
+        let mut f = self.f;
+        self.it.rfold(init, move |acc, item| fold(acc, &f(item)))
     }
 }
 
@@ -1007,6 +1027,16 @@ where
     #[inline]
     fn next(&mut self) -> Option<&B> {
         self.it.next().map(&self.f)
+    }
+
+    #[inline]
+    fn fold<Acc, Fold>(self, init: Acc, mut fold: Fold) -> Acc
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, &Self::Item) -> Acc,
+    {
+        let f = self.f;
+        self.it.fold(init, move |acc, item| fold(acc, f(item)))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -562,6 +562,15 @@ where
     fn count(self) -> usize {
         self.it.count()
     }
+
+    #[inline]
+    fn fold<Acc, Fold>(self, init: Acc, mut f: Fold) -> Acc
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, &Self::Item) -> Acc,
+    {
+        self.it.fold(init, move |acc, item| f(acc, &item))
+    }
 }
 
 impl<I> DoubleEndedStreamingIterator for Convert<I>
@@ -571,6 +580,15 @@ where
     #[inline]
     fn advance_back(&mut self) {
         self.item = self.it.next_back();
+    }
+
+    #[inline]
+    fn rfold<Acc, Fold>(self, init: Acc, mut f: Fold) -> Acc
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, &Self::Item) -> Acc,
+    {
+        self.it.rev().fold(init, move |acc, item| f(acc, &item))
     }
 }
 
@@ -610,6 +628,15 @@ where
     fn count(self) -> usize {
         self.it.count()
     }
+
+    #[inline]
+    fn fold<Acc, Fold>(self, init: Acc, mut f: Fold) -> Acc
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, &Self::Item) -> Acc,
+    {
+        self.it.fold(init, move |acc, item| f(acc, item))
+    }
 }
 
 impl<'a, I, T: ?Sized> DoubleEndedStreamingIterator for ConvertRef<'a, I, T>
@@ -619,6 +646,15 @@ where
     #[inline]
     fn advance_back(&mut self) {
         self.item = self.it.next_back();
+    }
+
+    #[inline]
+    fn rfold<Acc, Fold>(self, init: Acc, mut f: Fold) -> Acc
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, &Self::Item) -> Acc,
+    {
+        self.it.rev().fold(init, move |acc, item| f(acc, item))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -505,6 +505,15 @@ where
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
     }
+
+    #[inline]
+    fn fold<Acc, Fold>(self, init: Acc, mut f: Fold) -> Acc
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, Self::Item) -> Acc,
+    {
+        self.0.fold(init, move |acc, item| f(acc, item.clone()))
+    }
 }
 
 impl<I> DoubleEndedIterator for Cloned<I>
@@ -913,6 +922,15 @@ where
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
+    }
+
+    #[inline]
+    fn fold<Acc, Fold>(self, init: Acc, mut f: Fold) -> Acc
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, Self::Item) -> Acc,
+    {
+        self.0.fold(init, move |acc, item| f(acc, item.to_owned()))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -919,6 +919,18 @@ where
             FuseState::End => 0,
         }
     }
+
+    #[inline]
+    fn fold<Acc, Fold>(self, init: Acc, fold: Fold) -> Acc
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, &Self::Item) -> Acc,
+    {
+        match self.state {
+            FuseState::Start | FuseState::Middle => self.it.fold(init, fold),
+            FuseState::End => init,
+        }
+    }
 }
 
 /// A streaming iterator which transforms the elements of a streaming iterator.


### PR DESCRIPTION
The `for_each` method fills the lack of a normal `for` loop, and allows a more functional style compared to the idiom of `while let Some(item) = iter.next() {...}`.  This is a simple wrapper on `fold`, just like the standard `Iterator::for_each`.

The `fold` and `rfold` methods allow arbitrary reductions.  They also enable internal iteration that can be a boon to the performance of some iterators, especially if they can amortize conditional logic.  The iterator adaptors all forward to internal `fold` calls as much as possible.