### PR TITLE
Add warning on while let syntax

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,10 @@
 //! not with an expression that creates an iterator.
 //! For example, the following code will loop forever over the first element of the array:
 //!
-//! ```ignore
+//! ```no_run
+//! use streaming_iterator::{convert, StreamingIterator};
 //! let array = [0, 1, 2, 3];
+//!
 //! while let Some(item) = convert(array.iter()).next() {
 //!   // This is an infinite loop!
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,16 @@
 //! }
 //! ```
 //!
+//! However, **make sure to only use the above form with a mutable reference to an existing iterator**.
+//! For example, the following code will loop forever over the first element of the array:
+//!
+//! ```ignore
+//! let array = [0, 1, 2, 3];
+//! while let Some(item) = convert(array.iter()).next() {
+//!   // This is an infinite loop!
+//! }
+//! ```
+//!
 //! While the standard `Iterator` trait's functionality is based off of the `next` method,
 //! `StreamingIterator`'s functionality is based off of a pair of methods: `advance` and `get`. This
 //! essentially splits the logic of `next` in half (in fact, `StreamingIterator`'s `next` method

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,8 @@
 //! }
 //! ```
 //!
-//! However, **make sure to only use the above form with a mutable reference to an existing iterator**.
+//! However, **make sure to only use the above form with a mutable reference to an existing iterator**,
+//! not with an expression that creates an iterator.
 //! For example, the following code will loop forever over the first element of the array:
 //!
 //! ```ignore


### PR DESCRIPTION
A brief warning in bold about the following misuse of the `while let` syntax suggested in the docs:

```rust
let array = [0, 1, 2, 3];
while let Some(item) = convert(array.iter()).next() {
  // This is an infinite loop!
}
```

I got bitten by it while replacing regular iterators with streaming iterators and it took me quite a while to notice my mistake, so I think it's worth mentioning.