### PR TITLE
feat: is_done() ~= .get().is_none()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -573,7 +573,8 @@ where
 
         match self.state {
             BothForward | BothBackward => {
-                self.state = if self.a.next().is_none() {
+                self.a.advance();
+                self.state = if self.a.is_done() {
                     self.b.advance();
                     Back
                 } else {
@@ -635,7 +636,8 @@ where
 
         match self.state {
             BothForward | BothBackward => {
-                self.state = if self.b.next_back().is_none() {
+                self.b.advance_back();
+                self.state = if self.b.is_done() {
                     self.a.advance_back();
                     Front
                 } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,8 @@
 //! just a required `next` method, operations like `filter` would be impossible to define.
 #![doc(html_root_url = "https://docs.rs/streaming-iterator/0.1")]
 #![warn(missing_docs)]
+// for compatibility down to Rust 1.19 (`dyn` needs 1.27)
+#![allow(bare_trait_objects)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -916,7 +916,13 @@ where
 
     #[inline]
     fn advance(&mut self) {
-        while self.sub_iter.as_mut().and_then(J::next).is_none() {
+        loop {
+            if let Some(ref mut iter) = self.sub_iter {
+                iter.advance();
+                if !iter.is_done() {
+                    break;
+                }
+            }
             if let Some(item) = self.it.next() {
                 self.sub_iter = Some((self.f)(item));
             } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 #![doc(html_root_url = "https://docs.rs/streaming-iterator/0.1")]
 #![warn(missing_docs)]
 // for compatibility down to Rust 1.19 (`dyn` needs 1.27)
-#![allow(bare_trait_objects)]
+#![allow(unknown_lints, bare_trait_objects)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "std")]
@@ -1956,8 +1956,9 @@ mod test {
 
     #[test]
     fn is_done_map() {
-        let mut it = convert([1].iter().cloned())
-            .map_ref(|_: &u8| -> &u16 { panic!("only called during get()") });
+        let items = [1];
+        let mut it = convert(items.iter().cloned())
+            .map_ref::<u16, _>(|_| panic!("only called during get()"));
         it.advance();
         assert!(!it.is_done());
         it.advance();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1040,14 +1040,15 @@ where
         match self.state {
             FuseState::Start => {
                 self.it.advance();
-                self.state = match self.it.get() {
-                    Some(_) => FuseState::Middle,
-                    None => FuseState::End,
+                self.state = if self.it.is_done() {
+                    FuseState::End
+                } else {
+                    FuseState::Middle
                 };
             }
             FuseState::Middle => {
                 self.it.advance();
-                if let None = self.it.get() {
+                if self.it.is_done() {
                     self.state = FuseState::End;
                 }
             }
@@ -1059,7 +1060,7 @@ where
     fn is_done(&self) -> bool {
         match self.state {
             FuseState::Start | FuseState::End => true,
-            FuseState::Middle => self.it.is_done(),
+            FuseState::Middle => false,
         }
     }
 
@@ -1120,6 +1121,7 @@ where
         }
     }
 }
+
 /// A streaming iterator that calls a function with element before yielding it.
 #[derive(Debug)]
 pub struct Inspect<I, F> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,9 +223,11 @@ pub trait StreamingIterator {
         loop {
             self.advance();
             match self.get() {
-                Some(i) => if f(i) {
-                    break;
-                },
+                Some(i) => {
+                    if f(i) {
+                        break;
+                    }
+                }
                 None => break,
             }
         }
@@ -782,10 +784,12 @@ where
     fn advance(&mut self) {
         loop {
             match self.it.next() {
-                Some(i) => if let Some(i) = (self.f)(i) {
-                    self.item = Some(i);
-                    break;
-                },
+                Some(i) => {
+                    if let Some(i) = (self.f)(i) {
+                        self.item = Some(i);
+                        break;
+                    }
+                }
                 None => {
                     self.item = None;
                     break;
@@ -827,10 +831,12 @@ where
     fn advance_back(&mut self) {
         loop {
             match self.it.next_back() {
-                Some(i) => if let Some(i) = (self.f)(i) {
-                    self.item = Some(i);
-                    break;
-                },
+                Some(i) => {
+                    if let Some(i) = (self.f)(i) {
+                        self.item = Some(i);
+                        break;
+                    }
+                }
                 None => {
                     self.item = None;
                     break;
@@ -1506,12 +1512,14 @@ where
             None
         } else {
             match self.it.next() {
-                Some(i) => if (self.f)(i) {
-                    Some(i)
-                } else {
-                    self.done = true;
-                    None
-                },
+                Some(i) => {
+                    if (self.f)(i) {
+                        Some(i)
+                    } else {
+                        self.done = true;
+                        None
+                    }
+                }
                 None => None,
             }
         }


### PR DESCRIPTION
 * run rustfmt
 * fix a "missing `dyn`" warning
 * add an `is_done()`, which defaults to calling `.get().is_none()`, but can have a more efficient implementation for e.g. `MapRef`, which can avoid calling the mapping function during `nth`.

Also, please do a release, with or without this change. :)