### PR TITLE
Bump Rust Version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,25 @@ save_deps: &SAVE_DEPS
 
 version: 2
 jobs:
-  build:
+  build-MSRV:
     docker:
-      - image: rust:1.41.0
+      - image: rust:1.19.0
+    working_directory: ~/build
+    environment:
+      RUSTFLAGS: -D warnings
+    steps:
+      - checkout
+      - *RESTORE_REGISTRY
+      - run: cargo generate-lockfile
+      - *SAVE_REGISTRY
+      - run: rustc --version > ~/rust-version
+      - *RESTORE_DEPS
+      - run: cargo test
+      - run: cargo test --features std
+      - *SAVE_DEPS
+  build-latest:
+    docker:
+      - image: rust:latest
     working_directory: ~/build
     environment:
       RUSTFLAGS: -D warnings

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: rust:1.19.0
+      - image: rust:1.41.0
     working_directory: ~/build
     environment:
       RUSTFLAGS: -D warnings

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,24 @@ save_deps: &SAVE_DEPS
 
 version: 2
 jobs:
-  build:
+  build_MSRV:
     docker:
       - image: rust:1.19.0
+    working_directory: ~/build
+    environment:
+      RUSTFLAGS: -D warnings
+    steps:
+      - checkout
+      - *RESTORE_REGISTRY
+      - run: cargo generate-lockfile
+      - *SAVE_REGISTRY
+      - run: rustc --version > ~/rust-version
+      - *RESTORE_DEPS
+      - run: cargo test
+      - run: cargo test --features std
+      - *SAVE_DEPS
+  build_latest:
+    docker:
       - image: rust:latest
     working_directory: ~/build
     environment:
@@ -37,3 +52,10 @@ jobs:
       - run: cargo test
       - run: cargo test --features std
       - *SAVE_DEPS
+
+workflows:
+  version: 2
+  run_tests:
+    jobs:
+      - build_MSRV
+      - build_latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,24 +20,9 @@ save_deps: &SAVE_DEPS
 
 version: 2
 jobs:
-  build-MSRV:
+  build:
     docker:
       - image: rust:1.19.0
-    working_directory: ~/build
-    environment:
-      RUSTFLAGS: -D warnings
-    steps:
-      - checkout
-      - *RESTORE_REGISTRY
-      - run: cargo generate-lockfile
-      - *SAVE_REGISTRY
-      - run: rustc --version > ~/rust-version
-      - *RESTORE_DEPS
-      - run: cargo test
-      - run: cargo test --features std
-      - *SAVE_DEPS
-  build-latest:
-    docker:
       - image: rust:latest
     working_directory: ~/build
     environment:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@
 //! just a required `next` method, operations like `filter` would be impossible to define.
 #![doc(html_root_url = "https://docs.rs/streaming-iterator/0.1")]
 #![warn(missing_docs)]
+#![allow(unknown_lints, bare_trait_objects)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
Since 1.19 is fairly old, I figured it would be good to bump this version. Going forward I am not sure how to keep this fresh though.

**EDIT**: It looks like there will be some small language updates needed to use a more recent version of Rust too. I'm not sure if you want to use the 2018 features in this crate yet though. I would be happy to make a patch if so.