### PR TITLE
Add free fns as iterator sources

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ mod sources;
 pub use sources::{convert, Convert};
 pub use sources::{convert_ref, ConvertRef};
 pub use sources::{empty, Empty};
+pub use sources::{once, Once};
 
 /// An interface for dealing with streaming iterators.
 pub trait StreamingIterator {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,11 @@
 extern crate core;
 
 use core::cmp;
-use core::marker::PhantomData;
+
+mod sources;
+pub use sources::{convert, Convert};
+pub use sources::{convert_ref, ConvertRef};
+pub use sources::{empty, Empty};
 
 /// An interface for dealing with streaming iterators.
 pub trait StreamingIterator {
@@ -507,67 +511,6 @@ pub trait DoubleEndedStreamingIterator: StreamingIterator {
     }
 }
 
-/// Turns a normal, non-streaming iterator into a streaming iterator.
-///
-/// ```
-/// # use streaming_iterator::{StreamingIterator, convert};
-/// let scores = vec![100, 50, 80];
-/// let mut streaming_iter = convert(scores);
-/// while let Some(score) = streaming_iter.next() {
-///     println!("The score is: {}", score);
-/// }
-/// ```
-#[inline]
-pub fn convert<I>(it: I) -> Convert<I::IntoIter>
-where
-    I: IntoIterator,
-{
-    Convert { it: it.into_iter(), item: None }
-}
-
-/// Turns an iterator of references into a streaming iterator.
-#[inline]
-pub fn convert_ref<'a, I, T: ?Sized>(iterator: I) -> ConvertRef<'a, I::IntoIter, T>
-where
-    I: IntoIterator<Item = &'a T>,
-{
-    ConvertRef {
-        it: iterator.into_iter(),
-        item: None,
-    }
-}
-
-/// A simple iterator that returns nothing
-#[derive(Clone, Debug)]
-pub struct Empty<I> {
-    phantom: PhantomData<I>,
-}
-
-impl<I> StreamingIterator for Empty<I> {
-    type Item = I;
-
-    #[inline]
-    fn advance(&mut self) {}
-
-    #[inline]
-    fn get(&self) -> Option<&Self::Item> {
-        None
-    }
-}
-
-impl<I> DoubleEndedStreamingIterator for Empty<I> {
-    #[inline]
-    fn advance_back(&mut self) {}
-}
-
-/// Creates an empty iterator
-#[inline]
-pub fn empty<I>() -> Empty<I> {
-    Empty {
-        phantom: PhantomData,
-    }
-}
-
 /// A streaming iterator that concatenates two streaming iterators
 #[derive(Debug)]
 pub struct Chain<A, B> {
@@ -724,137 +667,6 @@ where
     #[inline]
     fn next_back(&mut self) -> Option<I::Item> {
         self.0.next_back().map(Clone::clone)
-    }
-}
-
-/// A streaming iterator which yields elements from a normal, non-streaming, iterator.
-#[derive(Clone, Debug)]
-pub struct Convert<I>
-where
-    I: Iterator,
-{
-    it: I,
-    item: Option<I::Item>,
-}
-
-impl<I> StreamingIterator for Convert<I>
-where
-    I: Iterator,
-{
-    type Item = I::Item;
-
-    #[inline]
-    fn advance(&mut self) {
-        self.item = self.it.next();
-    }
-
-    #[inline]
-    fn get(&self) -> Option<&I::Item> {
-        self.item.as_ref()
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.it.size_hint()
-    }
-
-    #[inline]
-    fn count(self) -> usize {
-        self.it.count()
-    }
-
-    #[inline]
-    fn fold<Acc, Fold>(self, init: Acc, mut f: Fold) -> Acc
-    where
-        Self: Sized,
-        Fold: FnMut(Acc, &Self::Item) -> Acc,
-    {
-        self.it.fold(init, move |acc, item| f(acc, &item))
-    }
-}
-
-impl<I> DoubleEndedStreamingIterator for Convert<I>
-where
-    I: DoubleEndedIterator,
-{
-    #[inline]
-    fn advance_back(&mut self) {
-        self.item = self.it.next_back();
-    }
-
-    #[inline]
-    fn rfold<Acc, Fold>(self, init: Acc, mut f: Fold) -> Acc
-    where
-        Self: Sized,
-        Fold: FnMut(Acc, &Self::Item) -> Acc,
-    {
-        self.it.rev().fold(init, move |acc, item| f(acc, &item))
-    }
-}
-
-/// A streaming iterator which yields elements from an iterator of references.
-#[derive(Clone, Debug)]
-pub struct ConvertRef<'a, I, T: ?Sized>
-where
-    I: Iterator<Item = &'a T>,
-    T: 'a,
-{
-    it: I,
-    item: Option<&'a T>,
-}
-
-impl<'a, I, T: ?Sized> StreamingIterator for ConvertRef<'a, I, T>
-where
-    I: Iterator<Item = &'a T>,
-{
-    type Item = T;
-
-    #[inline]
-    fn advance(&mut self) {
-        self.item = self.it.next();
-    }
-
-    #[inline]
-    fn get(&self) -> Option<&T> {
-        self.item
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.it.size_hint()
-    }
-
-    #[inline]
-    fn count(self) -> usize {
-        self.it.count()
-    }
-
-    #[inline]
-    fn fold<Acc, Fold>(self, init: Acc, mut f: Fold) -> Acc
-    where
-        Self: Sized,
-        Fold: FnMut(Acc, &Self::Item) -> Acc,
-    {
-        self.it.fold(init, move |acc, item| f(acc, item))
-    }
-}
-
-impl<'a, I, T: ?Sized> DoubleEndedStreamingIterator for ConvertRef<'a, I, T>
-where
-    I: DoubleEndedIterator<Item = &'a T>,
-{
-    #[inline]
-    fn advance_back(&mut self) {
-        self.item = self.it.next_back();
-    }
-
-    #[inline]
-    fn rfold<Acc, Fold>(self, init: Acc, mut f: Fold) -> Acc
-    where
-        Self: Sized,
-        Fold: FnMut(Acc, &Self::Item) -> Acc,
-    {
-        self.it.rev().fold(init, move |acc, item| f(acc, item))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ pub use sources::{once, Once};
 pub use sources::{once_with, OnceWith};
 pub use sources::{repeat, Repeat};
 pub use sources::{repeat_with, RepeatWith};
+pub use sources::{successors, Successors};
 
 /// An interface for dealing with streaming iterators.
 pub trait StreamingIterator {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub use sources::{empty, Empty};
 pub use sources::{from_fn, FromFn};
 pub use sources::{once, Once};
 pub use sources::{once_with, OnceWith};
+pub use sources::{repeat, Repeat};
 
 /// An interface for dealing with streaming iterators.
 pub trait StreamingIterator {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub use sources::{from_fn, FromFn};
 pub use sources::{once, Once};
 pub use sources::{once_with, OnceWith};
 pub use sources::{repeat, Repeat};
+pub use sources::{repeat_with, RepeatWith};
 
 /// An interface for dealing with streaming iterators.
 pub trait StreamingIterator {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ mod sources;
 pub use sources::{convert, Convert};
 pub use sources::{convert_ref, ConvertRef};
 pub use sources::{empty, Empty};
+pub use sources::{from_fn, FromFn};
 pub use sources::{once, Once};
 pub use sources::{once_with, OnceWith};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ pub use sources::{convert, Convert};
 pub use sources::{convert_ref, ConvertRef};
 pub use sources::{empty, Empty};
 pub use sources::{once, Once};
+pub use sources::{once_with, OnceWith};
 
 /// An interface for dealing with streaming iterators.
 pub trait StreamingIterator {

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -42,6 +42,15 @@ pub fn empty<T>() -> Empty<T> {
     }
 }
 
+/// Creates an iterator that returns exactly one item
+#[inline]
+pub fn once<T>(item: T) -> Once<T> {
+    Once {
+        first: true,
+        item: Some(item),
+    }
+}
+
 /// A streaming iterator which yields elements from a normal, non-streaming, iterator.
 #[derive(Clone, Debug)]
 pub struct Convert<I>
@@ -199,4 +208,42 @@ impl<T> StreamingIterator for Empty<T> {
 impl<T> DoubleEndedStreamingIterator for Empty<T> {
     #[inline]
     fn advance_back(&mut self) {}
+}
+
+/// A simple iterator that returns exactly one item.
+#[derive(Clone, Debug)]
+pub struct Once<T> {
+    first: bool,
+    item: Option<T>,
+}
+
+impl<T> StreamingIterator for Once<T> {
+    type Item = T;
+
+    #[inline]
+    fn advance(&mut self) {
+        if self.first {
+            self.first = false;
+        } else {
+            self.item = None;
+        }
+    }
+
+    #[inline]
+    fn get(&self) -> Option<&Self::Item> {
+        self.item.as_ref()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.first as usize;
+        (len, Some(len))
+    }
+}
+
+impl<T> DoubleEndedStreamingIterator for Once<T> {
+    #[inline]
+    fn advance_back(&mut self) {
+        self.advance();
+    }
 }

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -189,6 +189,11 @@ impl<T> StreamingIterator for Empty<T> {
     fn get(&self) -> Option<&Self::Item> {
         None
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(0))
+    }
 }
 
 impl<T> DoubleEndedStreamingIterator for Empty<T> {

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -1,0 +1,197 @@
+use super::{DoubleEndedStreamingIterator, StreamingIterator};
+use core::marker::PhantomData;
+
+/// Turns a normal, non-streaming iterator into a streaming iterator.
+///
+/// ```
+/// # use streaming_iterator::{StreamingIterator, convert};
+/// let scores = vec![100, 50, 80];
+/// let mut streaming_iter = convert(scores);
+/// while let Some(score) = streaming_iter.next() {
+///     println!("The score is: {}", score);
+/// }
+/// ```
+#[inline]
+pub fn convert<I>(it: I) -> Convert<I::IntoIter>
+where
+    I: IntoIterator,
+{
+    Convert {
+        it: it.into_iter(),
+        item: None,
+    }
+}
+
+/// Turns an iterator of references into a streaming iterator.
+#[inline]
+pub fn convert_ref<'a, I, T: ?Sized>(iterator: I) -> ConvertRef<'a, I::IntoIter, T>
+where
+    I: IntoIterator<Item = &'a T>,
+{
+    ConvertRef {
+        it: iterator.into_iter(),
+        item: None,
+    }
+}
+
+/// Creates an empty iterator.
+#[inline]
+pub fn empty<T>() -> Empty<T> {
+    Empty {
+        phantom: PhantomData,
+    }
+}
+
+/// A streaming iterator which yields elements from a normal, non-streaming, iterator.
+#[derive(Clone, Debug)]
+pub struct Convert<I>
+where
+    I: Iterator,
+{
+    it: I,
+    item: Option<I::Item>,
+}
+
+impl<I> StreamingIterator for Convert<I>
+where
+    I: Iterator,
+{
+    type Item = I::Item;
+
+    #[inline]
+    fn advance(&mut self) {
+        self.item = self.it.next();
+    }
+
+    #[inline]
+    fn get(&self) -> Option<&I::Item> {
+        self.item.as_ref()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.it.size_hint()
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.it.count()
+    }
+
+    #[inline]
+    fn fold<Acc, Fold>(self, init: Acc, mut f: Fold) -> Acc
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, &Self::Item) -> Acc,
+    {
+        self.it.fold(init, move |acc, item| f(acc, &item))
+    }
+}
+
+impl<I> DoubleEndedStreamingIterator for Convert<I>
+where
+    I: DoubleEndedIterator,
+{
+    #[inline]
+    fn advance_back(&mut self) {
+        self.item = self.it.next_back();
+    }
+
+    #[inline]
+    fn rfold<Acc, Fold>(self, init: Acc, mut f: Fold) -> Acc
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, &Self::Item) -> Acc,
+    {
+        self.it.rev().fold(init, move |acc, item| f(acc, &item))
+    }
+}
+
+/// A streaming iterator which yields elements from an iterator of references.
+#[derive(Clone, Debug)]
+pub struct ConvertRef<'a, I, T: ?Sized>
+where
+    I: Iterator<Item = &'a T>,
+    T: 'a,
+{
+    it: I,
+    item: Option<&'a T>,
+}
+
+impl<'a, I, T: ?Sized> StreamingIterator for ConvertRef<'a, I, T>
+where
+    I: Iterator<Item = &'a T>,
+{
+    type Item = T;
+
+    #[inline]
+    fn advance(&mut self) {
+        self.item = self.it.next();
+    }
+
+    #[inline]
+    fn get(&self) -> Option<&T> {
+        self.item
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.it.size_hint()
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.it.count()
+    }
+
+    #[inline]
+    fn fold<Acc, Fold>(self, init: Acc, mut f: Fold) -> Acc
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, &Self::Item) -> Acc,
+    {
+        self.it.fold(init, move |acc, item| f(acc, item))
+    }
+}
+
+impl<'a, I, T: ?Sized> DoubleEndedStreamingIterator for ConvertRef<'a, I, T>
+where
+    I: DoubleEndedIterator<Item = &'a T>,
+{
+    #[inline]
+    fn advance_back(&mut self) {
+        self.item = self.it.next_back();
+    }
+
+    #[inline]
+    fn rfold<Acc, Fold>(self, init: Acc, mut f: Fold) -> Acc
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, &Self::Item) -> Acc,
+    {
+        self.it.rev().fold(init, move |acc, item| f(acc, item))
+    }
+}
+
+/// A simple iterator that returns nothing.
+#[derive(Clone, Debug)]
+pub struct Empty<T> {
+    phantom: PhantomData<T>,
+}
+
+impl<T> StreamingIterator for Empty<T> {
+    type Item = T;
+
+    #[inline]
+    fn advance(&mut self) {}
+
+    #[inline]
+    fn get(&self) -> Option<&Self::Item> {
+        None
+    }
+}
+
+impl<T> DoubleEndedStreamingIterator for Empty<T> {
+    #[inline]
+    fn advance_back(&mut self) {}
+}

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -1,5 +1,6 @@
 use super::{DoubleEndedStreamingIterator, StreamingIterator};
 use core::marker::PhantomData;
+use core::usize;
 
 /// Turns a normal, non-streaming iterator into a streaming iterator.
 ///
@@ -64,6 +65,12 @@ pub fn once_with<T, F: FnOnce() -> T>(gen: F) -> OnceWith<T, F> {
         gen: Some(gen),
         item: None,
     }
+}
+
+/// Creates an iterator that returns an item endlessly.
+#[inline]
+pub fn repeat<T>(item: T) -> Repeat<T> {
+    Repeat { item }
 }
 
 /// A streaming iterator which yields elements from a normal, non-streaming, iterator.
@@ -319,4 +326,32 @@ impl<T, F: FnOnce() -> T> DoubleEndedStreamingIterator for OnceWith<T, F> {
     fn advance_back(&mut self) {
         self.advance();
     }
+}
+
+/// A simple iterator that repeats an item endlessly.
+#[derive(Clone, Debug)]
+pub struct Repeat<T> {
+    item: T,
+}
+
+impl<T> StreamingIterator for Repeat<T> {
+    type Item = T;
+
+    #[inline]
+    fn advance(&mut self) {}
+
+    #[inline]
+    fn get(&self) -> Option<&Self::Item> {
+        Some(&self.item)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (usize::MAX, None)
+    }
+}
+
+impl<T> DoubleEndedStreamingIterator for Repeat<T> {
+    #[inline]
+    fn advance_back(&mut self) {}
 }

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -42,7 +42,13 @@ pub fn empty<T>() -> Empty<T> {
     }
 }
 
-/// Creates an iterator that returns exactly one item
+/// Creates an iterator that returns items from a function call.
+#[inline]
+pub fn from_fn<T, F: FnMut() -> Option<T>>(gen: F) -> FromFn<T, F> {
+    FromFn { gen, item: None }
+}
+
+/// Creates an iterator that returns exactly one item.
 #[inline]
 pub fn once<T>(item: T) -> Once<T> {
     Once {
@@ -217,6 +223,27 @@ impl<T> StreamingIterator for Empty<T> {
 impl<T> DoubleEndedStreamingIterator for Empty<T> {
     #[inline]
     fn advance_back(&mut self) {}
+}
+
+/// A simple iterator that returns items from a function call.
+#[derive(Clone, Debug)]
+pub struct FromFn<T, F> {
+    gen: F,
+    item: Option<T>,
+}
+
+impl<T, F: FnMut() -> Option<T>> StreamingIterator for FromFn<T, F> {
+    type Item = T;
+
+    #[inline]
+    fn advance(&mut self) {
+        self.item = (self.gen)();
+    }
+
+    #[inline]
+    fn get(&self) -> Option<&Self::Item> {
+        self.item.as_ref()
+    }
 }
 
 /// A simple iterator that returns exactly one item.

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -24,6 +24,15 @@ where
 }
 
 /// Turns an iterator of references into a streaming iterator.
+///
+/// ```
+/// # use streaming_iterator::{StreamingIterator, convert_ref};
+/// let scores = vec![100, 50, 80];
+/// let mut streaming_iter = convert_ref(&scores);
+/// while let Some(score) = streaming_iter.next() {
+///     println!("The score is: {}", score);
+/// }
+/// ```
 #[inline]
 pub fn convert_ref<'a, I, T: ?Sized>(iterator: I) -> ConvertRef<'a, I::IntoIter, T>
 where
@@ -36,6 +45,12 @@ where
 }
 
 /// Creates an empty iterator.
+///
+/// ```
+/// # use streaming_iterator::StreamingIterator;
+/// let mut streaming_iter = streaming_iterator::empty::<i32>();
+/// assert_eq!(streaming_iter.next(), None);
+/// ```
 #[inline]
 pub fn empty<T>() -> Empty<T> {
     Empty {
@@ -44,12 +59,32 @@ pub fn empty<T>() -> Empty<T> {
 }
 
 /// Creates an iterator that returns items from a function call.
+///
+/// ```
+/// # use streaming_iterator::StreamingIterator;
+/// let mut count = 0;
+/// let mut streaming_iter = streaming_iterator::from_fn(|| {
+///     count += 1;
+///     if count < 4 { Some(count) } else { None }
+/// });
+/// assert_eq!(streaming_iter.next(), Some(&1));
+/// assert_eq!(streaming_iter.next(), Some(&2));
+/// assert_eq!(streaming_iter.next(), Some(&3));
+/// assert_eq!(streaming_iter.next(), None);
+/// ```
 #[inline]
 pub fn from_fn<T, F: FnMut() -> Option<T>>(gen: F) -> FromFn<T, F> {
     FromFn { gen, item: None }
 }
 
 /// Creates an iterator that returns exactly one item.
+///
+/// ```
+/// # use streaming_iterator::StreamingIterator;
+/// let mut streaming_iter = streaming_iterator::once(1);
+/// assert_eq!(streaming_iter.next(), Some(&1));
+/// assert_eq!(streaming_iter.next(), None);
+/// ```
 #[inline]
 pub fn once<T>(item: T) -> Once<T> {
     Once {
@@ -59,6 +94,15 @@ pub fn once<T>(item: T) -> Once<T> {
 }
 
 /// Creates an iterator that returns exactly one item from a function call.
+///
+/// ```
+/// # use streaming_iterator::StreamingIterator;
+/// #[derive(Debug, PartialEq)]
+/// struct Expensive(i32);
+/// let mut streaming_iter = streaming_iterator::once_with(|| Expensive(1));
+/// assert_eq!(streaming_iter.next(), Some(&Expensive(1)));
+/// assert_eq!(streaming_iter.next(), None);
+/// ```
 #[inline]
 pub fn once_with<T, F: FnOnce() -> T>(gen: F) -> OnceWith<T, F> {
     OnceWith {
@@ -68,18 +112,56 @@ pub fn once_with<T, F: FnOnce() -> T>(gen: F) -> OnceWith<T, F> {
 }
 
 /// Creates an iterator that returns an item endlessly.
+///
+/// ```
+/// # use streaming_iterator::StreamingIterator;
+/// let mut streaming_iter = streaming_iterator::repeat(1);
+/// assert_eq!(streaming_iter.next(), Some(&1));
+/// assert_eq!(streaming_iter.next(), Some(&1));
+/// assert_eq!(streaming_iter.next(), Some(&1));
+/// assert_eq!(streaming_iter.next(), Some(&1));
+/// assert_eq!(streaming_iter.next(), Some(&1));
+/// // ...
+/// ```
 #[inline]
 pub fn repeat<T>(item: T) -> Repeat<T> {
     Repeat { item }
 }
 
 /// Creates an iterator that endlessly returns items from a function call.
+///
+/// ```
+/// # use streaming_iterator::StreamingIterator;
+/// let mut count = 0;
+/// let mut streaming_iter = streaming_iterator::repeat_with(|| {
+///     count += 1;
+///     count
+/// });
+/// assert_eq!(streaming_iter.next(), Some(&1));
+/// assert_eq!(streaming_iter.next(), Some(&2));
+/// assert_eq!(streaming_iter.next(), Some(&3));
+/// assert_eq!(streaming_iter.next(), Some(&4));
+/// assert_eq!(streaming_iter.next(), Some(&5));
+/// // ...
+/// ```
 #[inline]
 pub fn repeat_with<T, F: FnMut() -> T>(gen: F) -> RepeatWith<T, F> {
     RepeatWith { gen, item: None }
 }
 
 /// Creates an iterator where each successive item is computed from the preceding one.
+///
+/// ```
+/// # use streaming_iterator::StreamingIterator;
+/// let mut streaming_iter = streaming_iterator::successors(
+///     Some(1),
+///     |count| if count < 3 { Some(count + 1) } else { None },
+/// );
+/// assert_eq!(streaming_iter.next(), Some(&1));
+/// assert_eq!(streaming_iter.next(), Some(&2));
+/// assert_eq!(streaming_iter.next(), Some(&3));
+/// assert_eq!(streaming_iter.next(), None);
+/// ```
 #[inline]
 pub fn successors<T, F: FnMut(T) -> Option<T>>(first: Option<T>, succ: F) -> Successors<T, F> {
     Successors {

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -73,6 +73,12 @@ pub fn repeat<T>(item: T) -> Repeat<T> {
     Repeat { item }
 }
 
+/// Creates an iterator that endlessly returns items from a function call.
+#[inline]
+pub fn repeat_with<T, F: FnMut() -> T>(gen: F) -> RepeatWith<T, F> {
+    RepeatWith { gen, item: None }
+}
+
 /// A streaming iterator which yields elements from a normal, non-streaming, iterator.
 #[derive(Clone, Debug)]
 pub struct Convert<I>
@@ -354,4 +360,30 @@ impl<T> StreamingIterator for Repeat<T> {
 impl<T> DoubleEndedStreamingIterator for Repeat<T> {
     #[inline]
     fn advance_back(&mut self) {}
+}
+
+/// A simple iterator that endlessly returns items from a function call.
+#[derive(Clone, Debug)]
+pub struct RepeatWith<T, F> {
+    gen: F,
+    item: Option<T>,
+}
+
+impl<T, F: FnMut() -> T> StreamingIterator for RepeatWith<T, F> {
+    type Item = T;
+
+    #[inline]
+    fn advance(&mut self) {
+        self.item = Some((self.gen)());
+    }
+
+    #[inline]
+    fn get(&self) -> Option<&Self::Item> {
+        self.item.as_ref()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (usize::MAX, None)
+    }
 }


### PR DESCRIPTION
These mimic the functions in `std::iter`. A couple of interesting differences are that `repeat` doesn't need `T: Clone` and that `successors` can transform by value, both because streaming iterators keep ownership of their items.