### PR TITLE
Add `StreamingIterator::copied`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streaming-iterator"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "Streaming iterators"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -883,7 +883,7 @@ where
 
     #[inline]
     fn next(&mut self) -> Option<I::Item> {
-        self.0.next().map(Clone::clone)
+        self.0.next().cloned()
     }
 
     #[inline]
@@ -908,7 +908,7 @@ where
 {
     #[inline]
     fn next_back(&mut self) -> Option<I::Item> {
-        self.0.next_back().map(Clone::clone)
+        self.0.next_back().cloned()
     }
 
     #[inline]


### PR DESCRIPTION
The standard library has had `Iterator::copied` since 1.36, so we should follow that.