### PR TITLE
add extension trait IntoStreamingIterator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: rust:1.31.0
+      - image: rust:1.56.0
     working_directory: ~/build
     environment:
       RUSTFLAGS: -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ license = "MIT OR Apache-2.0"
 description = "Streaming iterators"
 repository = "https://github.com/sfackler/streaming-iterator"
 readme = "README.md"
-edition = "2018"
-rust-version = "1.31"
+edition = "2021"
+rust-version = "1.56"
 
 [package.metadata.docs.rs]
 features = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2406,7 +2406,7 @@ where
 {
     /// Turns an [IntoIterator] into a [StreamingIterator].
     ///
-    /// Calling [into_streaming_iter](IntoStreamingIterator::into_streaming_iter) on an [IntoIterator] is equivalent to using [convert].
+    /// Calling this method on an [IntoIterator] is equivalent to using [convert].
     #[inline]
     fn into_streaming_iter(self) -> Convert<Self::IntoIter> {
         convert(self)
@@ -2414,7 +2414,7 @@ where
 
     /// Turns an [IntoIterator] of references into a [StreamingIterator].
     ///
-    /// Calling [into_streaming_iter_ref](IntoStreamingIterator::into_streaming_iter_ref) on an [IntoIterator] is equivalent to using [convert_ref].
+    /// Calling this method on an [IntoIterator] is equivalent to using [convert_ref].
     #[inline]
     fn into_streaming_iter_ref<'a, T: 'a>(self) -> ConvertRef<'a, Self::IntoIter, T>
     where
@@ -2425,7 +2425,7 @@ where
 
     /// Turns an [IntoIterator] of mutable references into a [StreamingIteratorMut].
     ///
-    /// Calling [into_streaming_iter_mut](IntoStreamingIterator::into_streaming_iter_mut) on an [IntoIterator] is equivalent to using [convert_mut].
+    /// Calling this method on an [IntoIterator] is equivalent to using [convert_mut].
     #[inline]
     fn into_streaming_iter_mut<'a, T: 'a>(self) -> ConvertMut<'a, Self::IntoIter, T>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2416,7 +2416,7 @@ where
     ///
     /// Calling this method on an [`IntoIterator`] is equivalent to using [`convert_ref`].
     #[inline]
-    fn into_streaming_iter_ref<'a, T: 'a>(self) -> ConvertRef<'a, Self::IntoIter, T>
+    fn into_streaming_iter_ref<'a, T: ?Sized>(self) -> ConvertRef<'a, Self::IntoIter, T>
     where
         Self: IntoIterator<Item = &'a T>,
     {
@@ -2427,7 +2427,7 @@ where
     ///
     /// Calling this method on an [`IntoIterator`] is equivalent to using [`convert_mut`].
     #[inline]
-    fn into_streaming_iter_mut<'a, T: 'a>(self) -> ConvertMut<'a, Self::IntoIter, T>
+    fn into_streaming_iter_mut<'a, T: ?Sized>(self) -> ConvertMut<'a, Self::IntoIter, T>
     where
         Self: IntoIterator<Item = &'a mut T>,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2399,22 +2399,22 @@ where
     }
 }
 
-/// Conversion from [IntoIterator] to [StreamingIterator].
+/// Conversion from [`IntoIterator`] to [`StreamingIterator`].
 pub trait IntoStreamingIterator: IntoIterator
 where
     Self: Sized,
 {
-    /// Turns an [IntoIterator] into a [StreamingIterator].
+    /// Turns an [`IntoIterator`] into a [`StreamingIterator`].
     ///
-    /// Calling this method on an [IntoIterator] is equivalent to using [convert].
+    /// Calling this method on an [`IntoIterator`] is equivalent to using [`convert`].
     #[inline]
     fn into_streaming_iter(self) -> Convert<Self::IntoIter> {
         convert(self)
     }
 
-    /// Turns an [IntoIterator] of references into a [StreamingIterator].
+    /// Turns an [`IntoIterator`] of references into a [`StreamingIterator`].
     ///
-    /// Calling this method on an [IntoIterator] is equivalent to using [convert_ref].
+    /// Calling this method on an [`IntoIterator`] is equivalent to using [`convert_ref`].
     #[inline]
     fn into_streaming_iter_ref<'a, T: 'a>(self) -> ConvertRef<'a, Self::IntoIter, T>
     where
@@ -2423,9 +2423,9 @@ where
         convert_ref(self)
     }
 
-    /// Turns an [IntoIterator] of mutable references into a [StreamingIteratorMut].
+    /// Turns an [`IntoIterator`] of mutable references into a [`StreamingIteratorMut`].
     ///
-    /// Calling this method on an [IntoIterator] is equivalent to using [convert_mut].
+    /// Calling this method on an [`IntoIterator`] is equivalent to using [`convert_mut`].
     #[inline]
     fn into_streaming_iter_mut<'a, T: 'a>(self) -> ConvertMut<'a, Self::IntoIter, T>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2399,6 +2399,44 @@ where
     }
 }
 
+/// Conversion from [IntoIterator] to [StreamingIterator].
+pub trait IntoStreamingIterator: IntoIterator
+where
+    Self: Sized,
+{
+    /// Turns an [IntoIterator] into a [StreamingIterator].
+    ///
+    /// Calling [into_streaming_iter](IntoStreamingIterator::into_streaming_iter) on an [IntoIterator] is equivalent to using [convert].
+    #[inline]
+    fn into_streaming_iter(self) -> Convert<Self::IntoIter> {
+        convert(self)
+    }
+
+    /// Turns an [IntoIterator] of references into a [StreamingIterator].
+    ///
+    /// Calling [into_streaming_iter_ref](IntoStreamingIterator::into_streaming_iter_ref) on an [IntoIterator] is equivalent to using [convert_ref].
+    #[inline]
+    fn into_streaming_iter_ref<'a, T: 'a>(self) -> ConvertRef<'a, Self::IntoIter, T>
+    where
+        Self: IntoIterator<Item = &'a T>,
+    {
+        convert_ref(self)
+    }
+
+    /// Turns an [IntoIterator] of mutable references into a [StreamingIteratorMut].
+    ///
+    /// Calling [into_streaming_iter_mut](IntoStreamingIterator::into_streaming_iter_mut) on an [IntoIterator] is equivalent to using [convert_mut].
+    #[inline]
+    fn into_streaming_iter_mut<'a, T: 'a>(self) -> ConvertMut<'a, Self::IntoIter, T>
+    where
+        Self: IntoIterator<Item = &'a mut T>,
+    {
+        convert_mut(self)
+    }
+}
+
+impl<I> IntoStreamingIterator for I where I: IntoIterator {}
+
 #[cfg(test)]
 mod test {
     use core::fmt::Debug;
@@ -2841,5 +2879,17 @@ mod test {
             .filter(|&i: &i32| i & 1 == 0)
             .for_each_mut(|i: &mut i32| *i /= 2);
         assert_eq!(items, [5, 11, 6, 13]);
+    }
+
+    #[test]
+    fn into_streaming_iter() {
+        let items = [0, 1, 2, 3];
+        let iter = items.into_streaming_iter();
+        test(iter, &items);
+        let iter = (&items).into_streaming_iter_ref();
+        test(iter, &items);
+        let mut mut_items = items;
+        let iter = (&mut mut_items).into_streaming_iter_mut();
+        test(iter, &items);
     }
 }


### PR DESCRIPTION
This PR adds an extension trait `IntoStreamingIterator` on `IntoIterator` which allows for more ergonomic method chaining.
Instead of having to use the `convert**` functions you can now use methods on iterators to convert them into streaming iterators.
This allows to use iterator adapters, convert into a streaming iterator and use streaming iterator adapters without breaking the method chain.